### PR TITLE
New feature: Continue on error for AST parsing errors.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,8 @@ Just use it as a standard command line tool if pip install properly.
 	  -p P                if plagiarism percentage of the function >= value then output detail (default: 0.5)
 	  -k, --keep-prints   keep print nodes
 	  -m, --module-level  process module level nodes
+	  -c, --continue-on-error
+	                      Continue on AST parsing error for candidate files. Reference code must be syntactically correct.
 
 	pycode_similar: error: too few arguments
 
@@ -58,8 +60,8 @@ Of course, you can use it as a python library, too.
 
 	import pycode_similar
 	pycode_similar.detect([referenced_code_str, candidate_code_str1, candidate_code_str2, ...], diff_method=pycode_similar.UnifiedDiff, keep_prints=False, module_level=False)
-	
-	
+
+
 Implementation
 --------------
 This tool has implemented two diff methods: line based diff(UnifiedDiff) and tree edit distance based diff(TreeDiff), both of them are run in function AST level.
@@ -75,7 +77,7 @@ Testing
 If you have the source code you can run the tests with
 
  `$ python pycode_similar/tests/test_cases.py`
- 
+
 Or perform
 
 .. code-block:: text
@@ -109,7 +111,7 @@ Or perform
 	0.92: ref FuncNodeCollector.__init__<18:4>, candidate FuncNodeCollector.__init__<20:4>
 	0.92: ref FuncNodeCollector.visit_Compare<108:4>, candidate FuncNodeCollector._simple_nomalize<117:8>
 	0.89: ref FuncNodeCollector.visit_Expr<79:4>, candidate FuncNodeCollector.visit_Expr<83:4>
-	
+
 Click `here  <https://github.com/fyrestone/pycode_similar/commit/149182beee460cbaf21d0995aa442a079ddf1fa9#diff-a30b425e81348c978616747430632fa8>`_
 to view this diff -> `0.92: ref FuncNodeCollector.visit_Compare<108:4>, candidate FuncNodeCollector._simple_nomalize<117:8>`
 
@@ -119,4 +121,4 @@ Repository
 The project is hosted on GitHub. You can look at the source here:
 
  https://github.com/fyrestone/pycode_similar
- 
+

--- a/pycode_similar/pycode_similar.py
+++ b/pycode_similar/pycode_similar.py
@@ -36,10 +36,8 @@ class BaseNodeNormalizer(ast.NodeTransformer):
     def _mark_docstring_sub_nodes(node):
         """
         Inspired by ast.get_docstring, mark all docstring sub nodes.
-
         Case1:
         regular docstring of function/class/module
-
         Case2:
         def foo(self):
             '''pure string expression'''
@@ -49,7 +47,6 @@ class BaseNodeNormalizer(ast.NodeTransformer):
             if self.abc:
                 '''pure string expression'''
                 pass
-
         Case3:
         def foo(self):
             if self.abc:
@@ -57,7 +54,6 @@ class BaseNodeNormalizer(ast.NodeTransformer):
             else:
                 '''pure string expression'''
                 pass
-
         :param node: every ast node
         :return:
         """
@@ -241,12 +237,9 @@ class FuncNodeCollector(BaseNodeNormalizer):
 class FuncInfo(object):
     """
     Part of the astor library for Python AST manipulation.
-
     License: 3-clause BSD
-
     Copyright 2012 (c) Patrick Maupin
     Copyright 2013 (c) Berker Peksag
-
     """
 
     class NonExistent(object):
@@ -322,16 +315,13 @@ class FuncInfo(object):
     @staticmethod
     def _iter_node(node, name='', missing=NonExistent):
         """Iterates over an object:
-
            - If the object has a _fields attribute,
              it gets attributes in the order of this
              and returns name, value pairs.
-
            - Otherwise, if the object is a list instance,
              it returns name, value pairs for each item
              in the list, where the name is passed into
              this function (defaults to blank).
-
         """
         fields = getattr(node, '_fields', None)
         if fields is not None:
@@ -347,10 +337,8 @@ class FuncInfo(object):
     def _dump(node, name=None, initial_indent='', indentation='    ',
               maxline=120, maxmerged=80, special=ast.AST):
         """Dumps an AST or similar structure:
-
            - Pretty-prints with indentation
            - Doesn't print line/column/ctx info
-
         """
 
         def _inner_dump(node, name=None, indent=''):
@@ -398,6 +386,7 @@ class FuncDiffInfo(object):
     info_candidate = None
     plagiarism_count = 0
     total_count = 0
+    ast_parsing_error = False
 
     @property
     def plagiarism_percent(self):
@@ -492,14 +481,30 @@ class NoFuncException(Exception):
         super(NoFuncException, self).__init__('Can not find any functions from code, index = {}'.format(source))
         self.source = source
 
+class AstParsingException(Exception):
+    def __int__(self, source):
+        super(AstParsingException, self).__init__('Can not parse code to AST, index = {}'.format(source))
+        self.source = source
 
-def detect(pycode_string_list, diff_method=UnifiedDiff, keep_prints=False, module_level=False):
+
+def detect(pycode_string_list, diff_method=UnifiedDiff, keep_prints=False, module_level=False, continue_on_error=False):
     if len(pycode_string_list) < 2:
         return []
 
     func_info_list = []
     for index, code_str in enumerate(pycode_string_list):
-        root_node = ast.parse(code_str)
+        try:
+            root_node = ast.parse(code_str)
+        except SyntaxError as e:
+            if continue_on_error and index != 0:
+                # print('warn: Can not parse code to AST, index = {}'.format(index))
+                func_info_list.append((index, None))
+                continue
+            elif continue_on_error and index == 0:
+                print('Error: Can not parse reference code to AST, can not continue.')
+                raise AstParsingException(index)
+            else:
+                raise AstParsingException(index)
         collector = FuncNodeCollector(keep_prints=keep_prints)
         collector.visit(root_node)
         code_utf8_lines = code_str.splitlines(True)
@@ -516,11 +521,22 @@ def detect(pycode_string_list, diff_method=UnifiedDiff, keep_prints=False, modul
 
     ast_diff_result = []
     index_ref, func_info_ref = func_info_list[0]
-    if len(func_info_ref) == 0:
+
+    if func_info_ref != None and len(func_info_ref) == 0:
         raise NoFuncException(index_ref)
 
     for index_candidate, func_info_candidate in func_info_list[1:]:
         func_ast_diff_list = []
+
+        if func_info_candidate == None: # AST not parsed
+            ast_error_func_diff_info = FuncDiffInfo()
+            ast_error_func_diff_info.info_ref = None
+            ast_error_func_diff_info.info_candidate = None
+            ast_error_func_diff_info.ast_parsing_error = True
+            ast_error_func_diff_info.plagiarism_count = -1
+            ast_error_func_diff_info.total_count = 1
+            ast_diff_result.append((index_candidate, [ast_error_func_diff_info]))
+            continue
 
         for fi1 in func_info_ref:
             min_diff_value = int((1 << 31) - 1)
@@ -598,8 +614,8 @@ def main():
         return open(value, 'rb')
 
     parser = ArgParser(description='A simple plagiarism detection tool for python code')
-    parser.add_argument('files', type=get_file, nargs=2,
-                        help='the input files')
+    parser.add_argument('files', type=get_file, nargs='+',
+                        help='the input files. First file being the reference file.')
     parser.add_argument('-l', type=check_line_limit, default=4,
                         help='if AST line of the function >= value then output detail (default: 4)')
     parser.add_argument('-p', type=check_percentage_limit, default=0.5,
@@ -608,6 +624,8 @@ def main():
                         help='keep print nodes')
     parser.add_argument('-m', '--module-level', action='store_true', default=False,
                         help='process module level nodes')
+    parser.add_argument('-c', '--continue-on-error', action='store_true', default=False,
+                        help='Continue on AST parsing error for candidate files. Reference code must be syntactically correct.')
     args = parser.parse_args()
     pycode_list = [(f.name, f.read()) for f in args.files]
     try:
@@ -615,6 +633,7 @@ def main():
             [c[1] for c in pycode_list],
             keep_prints=args.keep_prints,
             module_level=args.module_level,
+            continue_on_error=args.continue_on_error
         )
     except NoFuncException as ex:
         print('error: can not find functions from {}.'.format(pycode_list[ex.source][0]))
@@ -635,6 +654,9 @@ def main():
         ))
         output_count = 0
         for func_diff_info in func_ast_diff_list:
+            if func_diff_info.ast_parsing_error:
+                print('ERR : ast parsing error for candidate file')
+                continue
             if len(func_diff_info.info_ref.func_ast_lines) >= args.l and func_diff_info.plagiarism_percent >= args.p:
                 output_count = output_count + 1
                 print(func_diff_info)

--- a/pycode_similar/tests/test_cases.py
+++ b/pycode_similar/tests/test_cases.py
@@ -20,7 +20,7 @@ def foo(a):
 class A(object):
     def __init__(self, a):
         self._a = a
-        
+
     def bar(self):
         if self._a > 2:
             return True
@@ -101,8 +101,8 @@ def foo(a):
     \"""
     if a >= 1:
         return True
-        
-    # this should return False    
+
+    # this should return False
     return False
             """
         s2 = """
@@ -233,6 +233,33 @@ print(abs(el) * el for el in a if abs(el) > 2)
 
         result = pycode_similar.detect([s1, s2], module_level=True, keep_prints=True)
         self.assertGreater(result[0][1][0].plagiarism_percent, 0.5)
+
+    def test_syntax_error(self):
+        s1 = """
+def main():
+    s = 0
+    for j in range(10):
+        for i in range(10):
+            if i > j:
+                s += i + j
+    print(s)
+
+if __name__ == '__main__':
+    main()
+"""
+        s2 = """
+s = 0
+for j in range(10):
+    for i in range(10):
+        if i > j:
+            s += i + j
+print(s)?
+"""
+        result = pycode_similar.detect([s1, s2], module_level=True, continue_on_error=True)
+        self.assertEqual(result[0][1][0].ast_parsing_error, True)
+
+        with self.assertRaises(pycode_similar.AstParsingException) as context:
+            result = pycode_similar.detect([s1, s2], module_level=True, continue_on_error=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I'm checking plagiarism for a large number of code files (~1000). But when one of the code files contains syntax error, the program terminates and I will lose all the check results of other code pairs. To avoid that I added some logic to handle syntax errors. This flag can be enabled with `-c` / `--continue_on_error` from cli or `continue_on_error=True` when calling `detect()`. There's also a new test case `test_syntax_error` for that.

When enabled, candidate code file with syntax error will return a `FuncDiffInfo` with `ast_parsing_error` set to True. Reference code file must compile correctly though, even with `-c`.

This PR also fixes a small bug that cli can accept only two files.